### PR TITLE
feat: add Reset button for the Colors settings group

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ All settings take effect after closing the settings panel.
 |---|---|
 | Accent color | Primary accent used for links, borders, and highlights |
 | Body text color | Main document text color |
+| Bold text color | Color of `**bold**` / `<strong>` in body text. Headings are unaffected |
 | Heading color | Color applied to all heading levels |
 | Blockquote background | Fill color behind blockquote blocks |
 | Blockquote border | Left border color on blockquotes |

--- a/src/css-builder.ts
+++ b/src/css-builder.ts
@@ -284,7 +284,13 @@ export function buildDocCSS(s: PDFExportSettings, isRTL = false): string {
     ${isRTL ? "direction: rtl;" : ""}
   }
   .mpdf-doc *, .mpdf-doc *::before, .mpdf-doc *::after { box-sizing: border-box; }
-  .mpdf-doc strong, .mpdf-doc b { font-weight: 700; font-style: normal; }
+  .mpdf-doc strong, .mpdf-doc b { font-weight: 700; font-style: normal; color: ${s.boldColor}; }
+  .mpdf-doc h1 strong, .mpdf-doc h1 b,
+  .mpdf-doc h2 strong, .mpdf-doc h2 b,
+  .mpdf-doc h3 strong, .mpdf-doc h3 b,
+  .mpdf-doc h4 strong, .mpdf-doc h4 b,
+  .mpdf-doc h5 strong, .mpdf-doc h5 b,
+  .mpdf-doc h6 strong, .mpdf-doc h6 b { color: inherit; }
   .mpdf-doc em, .mpdf-doc i { font-style: italic; font-weight: inherit; }
   .mpdf-doc mark { background: #ffe066; color: inherit; padding: 0 2px; border-radius: 2px; }
   .mpdf-doc del, .mpdf-doc s { text-decoration: line-through; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,11 @@ export default class MarkdownPDFPlugin extends Plugin {
       this.settings.codeTheme = PRESETS[this.settings.preset]?.codeTheme ?? DEFAULT_SETTINGS.codeTheme;
     }
 
+    // Migration: boldColor was added per-preset; absent value keeps current body text color.
+    if (data.boldColor === undefined) {
+      this.settings.boldColor = this.settings.bodyColor;
+    }
+
     this.presetSnapshots = data.presetSnapshots ?? {};
     this.validateSettings();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@
 
 import { Menu, Plugin, TFile } from "obsidian";
 import {
-  DocStyle, PDFExportSettings, PRESETS, DEFAULT_SETTINGS, extractDocStyle,
+  DocStyle, PDFExportSettings, PRESETS, DEFAULT_SETTINGS, extractDocStyle, PRESET_COLOR_KEYS,
 } from "./settings";
 import { PDFExportModal } from "./export-modal";
 import { PDFExportSettingTab } from "./settings-tab";
@@ -127,5 +127,22 @@ export default class MarkdownPDFPlugin extends Plugin {
     }
     this.settings.preset = key;
     Object.assign(this.settings, p, reset ? {} : (this.presetSnapshots[key] ?? {}));
+  }
+
+  /** Restores the Colors-group pickers of the active preset to PRESETS defaults.
+   *  Other presets' snapshots and non-color settings are left untouched. */
+  resetPresetColors(): void {
+    const key = this.settings.preset;
+    const p = PRESETS[key];
+    if (!p) return;
+    for (const k of PRESET_COLOR_KEYS) {
+      this.settings[k] = p[k];
+    }
+    const snap = this.presetSnapshots[key];
+    if (snap) {
+      for (const k of PRESET_COLOR_KEYS) {
+        snap[k] = p[k];
+      }
+    }
   }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -234,6 +234,7 @@ export class PDFExportSettingTab extends PluginSettingTab {
       group("Colors", [
         color("Accent color", "accentColor"),
         color("Body text color", "bodyColor"),
+        color("Bold text color", "boldColor"),
         color("Heading color", "headingColor"),
         color("Blockquote background", "blockquoteBg"),
         color("Blockquote border", "blockquoteBorderColor"),

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -9,7 +9,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import {
-  App, PluginSettingTab,
+  App, PluginSettingTab, ButtonComponent,
   SettingDefinitionItem, SettingDefinitionControl, SettingDefinitionGroup, SettingGroupItem,
 } from "obsidian";
 import type MarkdownPDFPlugin from "./main";
@@ -231,19 +231,36 @@ export class PDFExportSettingTab extends PluginSettingTab {
         }, { visible: () => s.backgroundImageEnabled }),
       ]),
 
-      group("Colors", [
-        color("Accent color", "accentColor"),
-        color("Body text color", "bodyColor"),
-        color("Bold text color", "boldColor"),
-        color("Heading color", "headingColor"),
-        color("Blockquote background", "blockquoteBg"),
-        color("Blockquote border", "blockquoteBorderColor"),
-        color("Table header background", "tableHeaderBg"),
-        color("Code background", "codeBackground"),
-        dropdown("Code syntax theme", "codeTheme", codeThemeOptions, {
-          desc: "Independent of your Obsidian theme. \"None\" uses the body text color and code background above with no highlighting.",
-        }),
-      ]),
+      {
+        ...group("Colors", [
+          color("Accent color", "accentColor"),
+          color("Body text color", "bodyColor"),
+          color("Bold text color", "boldColor"),
+          color("Heading color", "headingColor"),
+          color("Blockquote background", "blockquoteBg"),
+          color("Blockquote border", "blockquoteBorderColor"),
+          color("Table header background", "tableHeaderBg"),
+          color("Code background", "codeBackground"),
+          dropdown("Code syntax theme", "codeTheme", codeThemeOptions, {
+            desc: "Independent of your Obsidian theme. \"None\" uses the body text color and code background above with no highlighting.",
+          }),
+        ]),
+        extraButtons: [
+          (extra) => {
+            const host = extra.extraSettingsEl.parentElement;
+            extra.extraSettingsEl.detach();
+            if (!host) return;
+            new ButtonComponent(host)
+              .setButtonText("Reset")
+              .setTooltip("Reset colors to this preset's defaults")
+              .onClick(() => {
+                this.plugin.resetPresetColors();
+                void this.markDirty();
+                this.update();
+              });
+          },
+        ],
+      },
 
       group("Header", [
         toggle("Show header", "showHeader"),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -356,6 +356,13 @@ export const DEFAULT_SETTINGS: PDFExportSettings = {
   includeOutline: true,
 };
 
+/** Color pickers in the Colors settings group. Used to reset only those
+ *  fields to the active preset's defaults without touching other DocStyle. */
+export const PRESET_COLOR_KEYS = [
+  "accentColor", "bodyColor", "boldColor", "headingColor",
+  "blockquoteBg", "blockquoteBorderColor", "tableHeaderBg", "codeBackground",
+] as const satisfies readonly (keyof DocStyle)[];
+
 /** Extracts only the DocStyle fields from the broader settings object.
  *  Used to snapshot the current look before switching presets, so each
  *  preset can remember per-user tweaks independently. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,7 @@ export interface DocStyle {
   headingScale: number;
   accentColor: string;
   bodyColor: string;
+  boldColor: string;
   headingColor: string;
   h1BorderBottom: boolean;
   h2BorderBottom: boolean;
@@ -130,6 +131,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 1.0,
     accentColor: "#7c6af7",
     bodyColor: "#1a1a2e",
+    boldColor: "#1a1a2e",
     headingColor: "#0d0d1a",
     h1BorderBottom: false,
     h2BorderBottom: true,
@@ -154,6 +156,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 0.88,
     accentColor: "#333",
     bodyColor: "#222",
+    boldColor: "#222",
     headingColor: "#111",
     h1BorderBottom: false,
     h2BorderBottom: false,
@@ -178,6 +181,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 0.95,
     accentColor: "#1a3a6b",
     bodyColor: "#000",
+    boldColor: "#000",
     headingColor: "#000",
     h1BorderBottom: true,
     h2BorderBottom: true,
@@ -202,6 +206,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 1.05,
     accentColor: "#e84393",
     bodyColor: "#1a1a2e",
+    boldColor: "#1a1a2e",
     headingColor: "#2d0a4e",
     h1BorderBottom: false,
     h2BorderBottom: false,
@@ -226,6 +231,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 1.0,
     accentColor: "#0070f3",
     bodyColor: "#111",
+    boldColor: "#111",
     headingColor: "#000",
     h1BorderBottom: false,
     h2BorderBottom: false,
@@ -250,6 +256,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 1.1,
     accentColor: "#111",
     bodyColor: "#111",
+    boldColor: "#111",
     headingColor: "#000",
     h1BorderBottom: true,
     h2BorderBottom: true,
@@ -274,6 +281,7 @@ export const PRESETS: Record<string, DocStyle> = {
     headingScale: 1.0,
     accentColor: "#818cf8",
     bodyColor: "#d1d5db",
+    boldColor: "#d1d5db",
     headingColor: "#f1f5f9",
     h1BorderBottom: false,
     h2BorderBottom: true,
@@ -356,7 +364,7 @@ export function extractDocStyle(s: PDFExportSettings): DocStyle {
     name: s.name, fontFamily: s.fontFamily, fontSize: s.fontSize,
     lineHeight: s.lineHeight, paragraphSpacing: s.paragraphSpacing,
     headingScale: s.headingScale, accentColor: s.accentColor,
-    bodyColor: s.bodyColor, headingColor: s.headingColor,
+    bodyColor: s.bodyColor, boldColor: s.boldColor, headingColor: s.headingColor,
     h1BorderBottom: s.h1BorderBottom, h2BorderBottom: s.h2BorderBottom,
     centerH1: s.centerH1, blockquoteBg: s.blockquoteBg,
     blockquoteBorderColor: s.blockquoteBorderColor, codeBackground: s.codeBackground,


### PR DESCRIPTION
## Summary
Adds a **Reset** button to the Colors section in Settings so color pickers can be restored to the active preset's defaults without resetting the rest of the style.
This is the remaining part of #42 (bold text color landed in #45).

Closes #42

## Behavior
- New **Reset** button on the Colors heading (tooltip: "Reset colors to this preset's defaults").
- Restores only the Colors-group pickers of the **current** preset:
  accent, body, bold, heading, blockquote background/border, table header background, and code background.
- Typography, margins, header/footer, and other non-color settings are left unchanged.
- Other presets' snapshots are not touched.
- The current preset snapshot is updated as well, so switching away and back keeps the reset colors.
- Distinct from **Reset Preset**, which still restores the entire style (fonts, spacing, colors, etc.).

<img width="718" height="375" alt="image" src="https://github.com/user-attachments/assets/77754fc3-869b-496b-a644-acc828eb7f5d" />
