### PR TITLE
Fix inconsistent heading styles

### DIFF
--- a/src/css-builder.ts
+++ b/src/css-builder.ts
@@ -317,7 +317,7 @@ export function buildDocCSS(s: PDFExportSettings, isRTL = false): string {
     margin: ${Math.round(16 * hs)}px 0 ${Math.round(8 * hs)}px;
     letter-spacing: 0.01em;
   }
-  .mpdf-doc h4 { font-size: ${Math.round(13 * hs)}px; font-weight: 700; color: ${s.headingColor}; margin: 12px 0 6px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .mpdf-doc h4 { font-size: ${Math.round(13 * hs)}px; font-weight: 700; color: ${s.headingColor}; margin: 12px 0 6px; letter-spacing: 0.04em; }
   .mpdf-doc h5 { font-size: ${Math.round(12 * hs)}px; font-weight: 600; color: ${s.headingColor}; margin: 10px 0 4px; font-style: italic; }
   .mpdf-doc h6 { font-size: ${Math.round(11 * hs)}px; font-weight: 600; color: ${s.bodyColor}; margin: 8px 0 4px; font-style: italic; opacity: 0.75; }
   .mpdf-doc p { margin: 0 0 ${s.paragraphSpacing}em; }

--- a/src/css-builder.ts
+++ b/src/css-builder.ts
@@ -305,7 +305,7 @@ export function buildDocCSS(s: PDFExportSettings, isRTL = false): string {
   }
   .mpdf-doc h2 {
     font-size: ${Math.round(17 * hs)}px;
-    font-weight: 600;
+    font-weight: 700;
     color: ${s.headingColor};
     margin: ${Math.round(20 * hs)}px 0 ${Math.round(10 * hs)}px;
     ${s.h2BorderBottom ? `border-bottom: 0.5px solid ${s.accentColor}55; padding-bottom: 5px;` : ""}


### PR DESCRIPTION
- Fixed H2 weight from 600 to 700.
- Removed uppercase styling from H4
Together these changes make the heading styling more consistent.

Before changes:
<img width="206" height="289" alt="Näyttökuva 2026-09-02 104315" src="https://github.com/user-attachments/assets/c84a15aa-3c0c-4e30-a75f-2b13aa042b52" />

After changes:
<img width="219" height="304" alt="Näyttökuva 2026-09-02 104228" src="https://github.com/user-attachments/assets/f0c7a42c-25e2-4bd0-b114-a49c7b374e98" />
